### PR TITLE
Require `python-ffmpeg` so it doesn't have to be installed manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ brew install ffmpeg
 
 # on Windows using Chocolatey (https://chocolatey.org/)
 choco install ffmpeg
-
-#you might also need python-ffmpeg
-
-pip3 install python-ffmpeg
 ```
 
 ## How to make it use your GPU for 3x faster generations

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     install_requires=[
         'youtube-dl',
         'psutil',
-        'openai-whisper'
+        'openai-whisper',
+        'python-ffmpeg',
     ],
     description="Automatically generate and/or embed subtitles into your videos",
     entry_points={


### PR DESCRIPTION
If we require `python-ffmpeg` in `setup.py`, then one doesn't have to install it manually.

Tested to be working fine when installing in isolated environment using uv, i.e. `uv tool install git+<repo-path>`.

`ffmpeg` still needs to be installed with its binary exposed on PATH.